### PR TITLE
Parse diskutil stdout using it's plist output, rather than regex

### DIFF
--- a/diskutil/diskutil.go
+++ b/diskutil/diskutil.go
@@ -2,6 +2,7 @@ package diskutil
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -9,7 +10,6 @@ import (
 	"os/exec"
 	"regexp"
 	"sort"
-	"strconv"
 	"time"
 
 	"apfs-snapshot-diff-clone/snapshot"
@@ -31,90 +31,72 @@ func (d DiskUtil) Rename(volume string, name string) error {
 }
 
 type VolumeInfo struct {
-	UUID       string
-	Name       string
-	MountPoint string
+	UUID       string `json:"VolumeUUID"`
+	Name       string `json:"VolumeName"`
+	MountPoint string `json:"MountPoint"`
 }
 
 func (d DiskUtil) Info(volume string) (VolumeInfo, error) {
-	cmd := exec.Command("diskutil", "info", volume)
-	stdoutPipe, err := cmd.StdoutPipe()
+	cmd := exec.Command("diskutil", "info", "-plist", volume)
+	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return VolumeInfo{}, fmt.Errorf("error creating stdout pipe: %v", err)
 	}
-	stdout := io.TeeReader(stdoutPipe, os.Stdout)
 	stderr := new(bytes.Buffer)
 	cmd.Stderr = stderr
-
 	log.Printf("Running command:\n%s", cmd)
 	if err := cmd.Start(); err != nil {
 		return VolumeInfo{}, fmt.Errorf("`%s` failed to start: %v", cmd, err)
 	}
-	output, err := io.ReadAll(stdout)
-	if err != nil {
-		return VolumeInfo{}, fmt.Errorf("error reading stdout: %v", err)
+	var info VolumeInfo
+	if err := decodePlist(stdout, &info); err != nil {
+		return VolumeInfo{}, fmt.Errorf("error parsing plist: %v", err)
 	}
 	if err := cmd.Wait(); err != nil {
 		return VolumeInfo{}, fmt.Errorf("`%s` failed (%v) with stderr: %s", cmd, err, stderr)
 	}
-
-	return parseInfo(output)
-}
-
-func parseInfo(info []byte) (VolumeInfo, error) {
-	re := regexp.MustCompile(
-		// Match and capture volume mount point.
-		`Volume Name: +(.+)` +
-
-		// Match (but do not capture) any line. This makes the regex
-		// pattern less brittle, as it will still match even if the
-		// order of the fields after mount point are changed.
-		`(?:\n.*)*` +
-
-		// Match and capture volume mount point.
-		`Mount Point: +(.+)` +
-
-		`(?:\n.*)*` +
-
-		// Match and capture volume UUID.
-		`Volume UUID: +([A-Z0-9-]+)`)
-	matches := re.FindSubmatch(info)
-	if len(matches) == 0 {
-		return VolumeInfo{}, fmt.Errorf("pattern %q did not match snapshot text:\n%q", re, info)
-	}
-	return VolumeInfo{
-		Name:       string(matches[1]),
-		MountPoint: string(matches[2]),
-		UUID:       string(matches[3]),
-	}, nil
+	return info, nil
 }
 
 func (d DiskUtil) ListSnapshots(volume string) ([]snapshot.Snapshot, error) {
-	cmd := exec.Command("diskutil", "apfs", "listsnapshots", volume)
-	stdoutPipe, err := cmd.StdoutPipe()
+	cmd := exec.Command("diskutil", "apfs", "listsnapshots", "-plist", volume)
+	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, fmt.Errorf("error creating stdout pipe: %v", err)
 	}
-	stdout := io.TeeReader(stdoutPipe, os.Stdout)
 	stderr := new(bytes.Buffer)
 	cmd.Stderr = stderr
-
 	log.Printf("Running command:\n%s", cmd)
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("`%s` failed to start: %v", cmd, err)
 	}
-	output, err := io.ReadAll(stdout)
-	if err != nil {
-		return nil, fmt.Errorf("error reading stdout: %v", err)
+	var snapshotList struct {
+		Snapshots []struct{
+			Name string `json:"SnapshotName"`
+			UUID string `json:"SnapshotUUID"`
+		} `json:"Snapshots"`
+	}
+	if err := decodePlist(stdout, &snapshotList); err != nil {
+		return nil, fmt.Errorf("error parsing plist: %v", err)
 	}
 	if err := cmd.Wait(); err != nil {
 		return nil, fmt.Errorf("`%s` failed (%v) with stderr: %s", cmd, err, stderr)
 	}
 
-	snapshots, err := parseSnapshotList(output)
-	if err != nil {
-		return nil, err
+	var snapshots []snapshot.Snapshot
+	for _, snap := range snapshotList.Snapshots {
+		created, err := parseTimeFromSnapshotName(snap.Name)
+		if err != nil {
+			return nil, err
+		}
+		snapshots = append(snapshots, snapshot.Snapshot{
+			Name:    snap.Name,
+			UUID:    snap.UUID,
+			Created: created,
+		})
 	}
+
+	// TODO: document why we sort here.
 	isSorted := sort.SliceIsSorted(snapshots, func(i, ii int) bool {
 		lhs := snapshots[i]
 		rhs := snapshots[ii]
@@ -129,65 +111,42 @@ func (d DiskUtil) ListSnapshots(volume string) ([]snapshot.Snapshot, error) {
 	return snapshots, nil
 }
 
-func parseSnapshotList(stdout []byte) ([]snapshot.Snapshot, error) {
-	headerRegex := regexp.MustCompile(`Snapshots? for [a-z0-9]+ \((\d+) found\)`)
-	headerMatches := headerRegex.FindSubmatch(stdout)
-	if len(headerMatches) == 0 {
-		return nil, nil
-	}
-	numSnapshots, err := strconv.Atoi(string(headerMatches[1]))
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse header (%q): %v", headerMatches[0], err)
-	}
-
-	listRegex := regexp.MustCompile(`\+-- .*(?:\n\|? .*)+`)
-	listMatches := listRegex.FindAll(stdout, -1)
-	if len(listMatches) != numSnapshots {
-		return nil, fmt.Errorf("found %d snapshots in list, but header claimed %d snapshots", len(listMatches), numSnapshots)
-	}
-	var snapshots []snapshot.Snapshot
-	for _, match := range listMatches {
-		snap, err := parseSnapshot(match)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse snapshot: %v", err)
-		}
-		snapshots = append(snapshots, snap)
-	}
-	return snapshots, nil
-}
-
-func parseSnapshot(snap []byte) (snapshot.Snapshot, error) {
-	snapshotRegex := regexp.MustCompile(
-		// Match and capture UUID.
-		`\+-- ([A-Z0-9-]+)` +
-
-		// Match (but do not capture) any line. This makes the regex
-		// pattern less brittle, as it will still match even if the
-		// order of the fields after UUID are changed.
-		`(?:\n.*)*` +
-
-		// Match and capture Name.
-		`\|? +Name: +([a-zA-Z0-9.-]+)`)
-	snapshotMatches := snapshotRegex.FindSubmatch(snap)
-	if len(snapshotMatches) == 0 {
-		return snapshot.Snapshot{}, fmt.Errorf("pattern %q did not match snapshot text:\n%q", snapshotRegex, snap)
-	}
-	uuid := snapshotMatches[1]
-	name := snapshotMatches[2]
-
+func parseTimeFromSnapshotName(name string) (time.Time, error) {
 	timeRegex := regexp.MustCompile(`\d{4}-\d{2}-\d{2}-\d{6}`)
-	timeMatch := timeRegex.Find(name)
+	timeMatch := timeRegex.FindString(name)
 	if len(timeMatch) == 0 {
-		return snapshot.Snapshot{}, fmt.Errorf("snapshot name (%q) does not contain a timestamp of the form yyyy-mm-dd-hhmmss", name)
+		return time.Time{}, fmt.Errorf("snapshot name (%q) does not contain a timestamp of the form yyyy-mm-dd-hhmmss", name)
 	}
 	created, err := time.Parse("2006-01-02-150405", string(timeMatch))
 	if err != nil {
-		return snapshot.Snapshot{}, fmt.Errorf("failed to parse time substring (%q) from snapshot name", timeMatch)
+		return time.Time{}, fmt.Errorf("failed to parse time substring (%q) from snapshot name", timeMatch)
 	}
+	return created, nil
+}
 
-	return snapshot.Snapshot{
-		Name:    string(name),
-		UUID:    string(uuid),
-		Created: created,
-	}, nil
+func decodePlist(r io.Reader, v interface{}) error {
+	cmd := exec.Command(
+		"plutil",
+		"-convert", "json",
+		// Read from stdin.
+		"-r", "-",
+		// Output to stdout.
+		"-o", "-")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("error creating stdout pipe: %v", err)
+	}
+	cmd.Stdin = r
+	stderr := new(bytes.Buffer)
+	cmd.Stderr = stderr
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("`%s` failed to start: %v", cmd, err)
+	}
+	if err := json.NewDecoder(stdout).Decode(v); err != nil {
+		return fmt.Errorf("failed to parse json: %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		return fmt.Errorf("`%s` failed (%v) with stderr: %s", cmd, err, stderr)
+	}
+	return nil
 }


### PR DESCRIPTION
The current method of using regex to parse diskutil's stdout is somewhat
brittle (plus I'm not confident in my regex-foo). This commit uses MacOS's
plutil to convert diskutil's plist output to JSON, and then parses the JSON to
the resulting structs.

I'd rather parse the plist output in Go directly, but it seems that this is not
trivial with the stdlib (https://stackoverflow.com/questions/38657880/parsing-plist-xml) , and I'd rather not add dependencies for this small
project.