### PR TITLE
Add --prune flag to prune common snapshot from target after restore

### DIFF
--- a/diskutil/diskutil.go
+++ b/diskutil/diskutil.go
@@ -117,6 +117,19 @@ func parseTimeFromSnapshotName(name string) (time.Time, error) {
 	return created, nil
 }
 
+func (d DiskUtil) DeleteSnapshot(volume string, snap Snapshot) error {
+	cmd := exec.Command("diskutil", "apfs", "deletesnapshot", volume, "-uuid", snap.UUID)
+	cmd.Stdout = os.Stdout
+	stderr := new(bytes.Buffer)
+	cmd.Stderr = stderr
+
+	log.Printf("Running command:\n%s", cmd)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("`%s` failed (%v) with stderr: %s", cmd, err, stderr)
+	}
+	return nil
+}
+
 func decodePlist(r io.Reader, v interface{}) error {
 	cmd := exec.Command(
 		"plutil",

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 var (
 	source = flag.String("source", "", "source APFS volume to clone - may be a mount point, /dev/ path, or volume UUID")
 	targets targetsFlag
+	prune = flag.Bool("prune", false, "prune the latest snapshot that source and target had in common before the clone")
 )
 
 func init() {
@@ -37,7 +38,7 @@ func main() {
 
 	errs := make(map[string]error) // Map of target volume to clone error.
 	for _, target := range targets {
-		c := cloner.New()
+		c := cloner.New(cloner.Prune(*prune))
 		if err := c.Clone(*source, target); err != nil {
 			errs[target] = err
 			log.Printf("failed to clone %q to %q: %v", *source, target, err)


### PR DESCRIPTION
This way old snapshots don't continue to build up over time on the target
volumes. Note that this does not delete any snapshots from the source volume,
since for my use case I might not have all the target volumes on-site at the
same time.