### PR TITLE
Test for the existence of specified args in fakecmd

### DIFF
--- a/asr/asr.go
+++ b/asr/asr.go
@@ -24,6 +24,7 @@ func New() ASR {
 }
 
 func (a ASR) Restore(source, target diskutil.VolumeInfo, to, from diskutil.Snapshot) error {
+	// TODO: ID volumes by Device instead of MountPoint.
 	cmd := a.execCommand(
 		"asr", "restore",
 		"--source", source.MountPoint,

--- a/asr/asr.go
+++ b/asr/asr.go
@@ -24,11 +24,10 @@ func New() ASR {
 }
 
 func (a ASR) Restore(source, target diskutil.VolumeInfo, to, from diskutil.Snapshot) error {
-	// TODO: ID volumes by Device instead of MountPoint.
 	cmd := a.execCommand(
 		"asr", "restore",
-		"--source", source.MountPoint,
-		"--target", target.MountPoint,
+		"--source", source.Device,
+		"--target", target.Device,
 		"--toSnapshot", to.UUID,
 		"--fromSnapshot", from.UUID,
 		"--erase", "--noprompt")

--- a/asr/asr_darwin_test.go
+++ b/asr/asr_darwin_test.go
@@ -32,7 +32,7 @@ func TestRestore(t *testing.T) {
 	}
 
 	du := diskutil.New()
-	got, err := du.ListSnapshots(target.UUID)
+	got, err := du.ListSnapshots(target)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/asr/asr_test.go
+++ b/asr/asr_test.go
@@ -49,6 +49,9 @@ func TestRestore_WritesOutputToStdout(t *testing.T) {
 	}
 }
 
+// Test that Restore:
+//   1. IDs volumes by MountPoint.
+//   2. IDs snapshots by UUID.
 func TestRestore_CmdArgs(t *testing.T) {
 	source := diskutil.VolumeInfo{
 		UUID:       "source-volume-uuid",
@@ -73,12 +76,12 @@ func TestRestore_CmdArgs(t *testing.T) {
 
 	a := New()
 	a.execCommand = fakecmd.FakeCommand(t, fakecmd.Options{
-		WantArgs: map[string]map[string]string{
-			"asr": map[string]string{
-				"--source":       source.MountPoint,
-				"--target":       target.MountPoint,
-				"--toSnapshot":   to.UUID,
-				"--fromSnapshot": from.UUID,
+		WantArgs: map[string]map[string]bool{
+			"asr": map[string]bool{
+				source.MountPoint: true,
+				target.MountPoint: true,
+				to.UUID:           true,
+				from.UUID:         true,
 			},
 		},
 	})

--- a/asr/asr_test.go
+++ b/asr/asr_test.go
@@ -50,7 +50,7 @@ func TestRestore_WritesOutputToStdout(t *testing.T) {
 }
 
 // Test that Restore:
-//   1. IDs volumes by MountPoint.
+//   1. IDs volumes by device node.
 //   2. IDs snapshots by UUID.
 func TestRestore_CmdArgs(t *testing.T) {
 	source := diskutil.VolumeInfo{
@@ -78,10 +78,10 @@ func TestRestore_CmdArgs(t *testing.T) {
 	a.execCommand = fakecmd.FakeCommand(t, fakecmd.Options{
 		WantArgs: map[string]map[string]bool{
 			"asr": map[string]bool{
-				source.MountPoint: true,
-				target.MountPoint: true,
-				to.UUID:           true,
-				from.UUID:         true,
+				source.Device: true,
+				target.Device: true,
+				to.UUID:       true,
+				from.UUID:     true,
 			},
 		},
 	})

--- a/cloner/cloner_darwin_test.go
+++ b/cloner/cloner_darwin_test.go
@@ -70,6 +70,9 @@ func TestClone(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			// Ignore mount point because `asr` remounts the target in the default
+			// /Volumes mount root, which will be different than our temporary test
+			// directory mount point.
 			ignoreMountPointOpt := cmpopts.IgnoreFields(diskutil.VolumeInfo{}, "MountPoint")
 			if diff := cmp.Diff(wantTargetInfo, gotTargetInfo, ignoreMountPointOpt); diff != "" {
 				t.Errorf("Clone resulted in unexpected target VolumeInfo. -want +got:\n%s", diff)

--- a/cloner/cloner_darwin_test.go
+++ b/cloner/cloner_darwin_test.go
@@ -75,7 +75,7 @@ func TestClone(t *testing.T) {
 				t.Errorf("Clone resulted in unexpected target VolumeInfo. -want +got:\n%s", diff)
 			}
 
-			gotTargetSnaps, err := du.ListSnapshots(target)
+			gotTargetSnaps, err := du.ListSnapshots(gotTargetInfo)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cloner/cloner_fakes_test.go
+++ b/cloner/cloner_fakes_test.go
@@ -101,44 +101,32 @@ func (du *fakeDiskUtil) Info(volume string) (diskutil.VolumeInfo, error) {
 	return du.devices.Volume(volume)
 }
 
-func (du *fakeDiskUtil) Rename(volume string, name string) error {
-	info, err := du.devices.Volume(volume)
-	if err != nil {
-		return err
-	}
-	snaps, err := du.devices.Snapshots(info.UUID)
+func (du *fakeDiskUtil) Rename(volume diskutil.VolumeInfo, name string) error {
+	snaps, err := du.devices.Snapshots(volume.UUID)
 	if err != nil {
 		return err
 	}
 
-	if err := du.devices.RemoveVolume(info.UUID); err != nil {
+	if err := du.devices.RemoveVolume(volume.UUID); err != nil {
 		return err
 	}
-	info.Name = name
-	return du.devices.AddVolume(info, snaps...)
+	volume.Name = name
+	return du.devices.AddVolume(volume, snaps...)
 }
 
-func (du *fakeDiskUtil) ListSnapshots(volume string) ([]diskutil.Snapshot, error) {
-	info, err := du.devices.Volume(volume)
-	if err != nil {
-		return nil, err
-	}
-	return du.devices.Snapshots(info.UUID)
+func (du *fakeDiskUtil) ListSnapshots(volume diskutil.VolumeInfo) ([]diskutil.Snapshot, error) {
+	return du.devices.Snapshots(volume.UUID)
 }
 
-func (du *fakeDiskUtil) DeleteSnapshot(volume string, snap diskutil.Snapshot) error {
-	info, err := du.devices.Volume(volume)
-	if err != nil {
-		return err
-	}
-	return du.devices.DeleteSnapshot(info.UUID, snap.UUID)
+func (du *fakeDiskUtil) DeleteSnapshot(volume diskutil.VolumeInfo, snap diskutil.Snapshot) error {
+	return du.devices.DeleteSnapshot(volume.UUID, snap.UUID)
 }
 
 type DiskUtil interface {
 	Info(volume string) (diskutil.VolumeInfo, error)
-	Rename(volume string, name string) error
-	ListSnapshots(volume string) ([]diskutil.Snapshot, error)
-	DeleteSnapshot(volume string, snap diskutil.Snapshot) error
+	Rename(volume diskutil.VolumeInfo, name string) error
+	ListSnapshots(volume diskutil.VolumeInfo) ([]diskutil.Snapshot, error)
+	DeleteSnapshot(volume diskutil.VolumeInfo, snap diskutil.Snapshot) error
 }
 
 type readonlyFakeDiskUtil struct {
@@ -151,7 +139,7 @@ func (du *readonlyFakeDiskUtil) Info(volume string) (diskutil.VolumeInfo, error)
 	return du.du.Info(volume)
 }
 
-func (du *readonlyFakeDiskUtil) ListSnapshots(volume string) ([]diskutil.Snapshot, error) {
+func (du *readonlyFakeDiskUtil) ListSnapshots(volume diskutil.VolumeInfo) ([]diskutil.Snapshot, error) {
 	return du.du.ListSnapshots(volume)
 }
 

--- a/cloner/cloner_test.go
+++ b/cloner/cloner_test.go
@@ -10,6 +10,8 @@ import (
 	"apfs-snapshot-diff-clone/diskutil"
 )
 
+// TODO: how can we verify that Clone calls all DiskUtil methods with the volume UUID (rather than volume mount point)?
+
 func TestClone(t *testing.T) {
 	snap1 := diskutil.Snapshot{
 		Name:    "common-snap",

--- a/cloner/cloner_test.go
+++ b/cloner/cloner_test.go
@@ -124,11 +124,19 @@ func TestClone(t *testing.T) {
 				t.Fatalf("Clone(...) returned unexpected error: %q, want: nil", err)
 			}
 
-			gotSourceSnaps, err := du.ListSnapshots(test.source)
+			sourceInfo, err := du.Info(test.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			targetInfo, err := du.Info(test.target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			gotSourceSnaps, err := du.ListSnapshots(sourceInfo)
 			if err != nil {
 				t.Fatalf("error listing snapshots: %v", err)
 			}
-			gotTargetSnaps, err := du.ListSnapshots(test.target)
+			gotTargetSnaps, err := du.ListSnapshots(targetInfo)
 			if err != nil {
 				t.Fatalf("error listing snapshots: %v", err)
 			}

--- a/cloner/cloner_test.go
+++ b/cloner/cloner_test.go
@@ -10,8 +10,6 @@ import (
 	"apfs-snapshot-diff-clone/diskutil"
 )
 
-// TODO: how can we verify that Clone calls all DiskUtil methods with the volume UUID (rather than volume mount point)?
-
 func TestClone(t *testing.T) {
 	snap1 := diskutil.Snapshot{
 		Name:    "common-snap",

--- a/diskutil/diskutil_test.go
+++ b/diskutil/diskutil_test.go
@@ -179,6 +179,15 @@ func TestInfo_Errors(t *testing.T) {
 	}
 }
 
+var (
+	exampleVolumeInfo = VolumeInfo{
+		Name:       "Example Volume",
+		UUID:       "example-volume-uuid",
+		MountPoint: "/example/volume",
+		Device:     "/dev/example-volume",
+	}
+)
+
 func TestListSnapshots(t *testing.T) {
 	tests := []struct{
 		name       string
@@ -251,7 +260,7 @@ func TestListSnapshots(t *testing.T) {
 				WantStdins: test.wantStdins,
 			}
 			du := newWithFakeCmd(t, fakeCmdOpts)
-			got, err := du.ListSnapshots("/example/volume")
+			got, err := du.ListSnapshots(exampleVolumeInfo)
 			if err := fakecmd.AsHelperProcessErr(err); err != nil {
 				t.Fatal(err)
 			}
@@ -364,7 +373,7 @@ func TestListSnapshots_Errors(t *testing.T) {
 				ExitFails:  test.exitFails,
 			}
 			du := newWithFakeCmd(t, fakeCmdOpts)
-			_, err := du.ListSnapshots("/example/volume")
+			_, err := du.ListSnapshots(exampleVolumeInfo)
 			if err := fakecmd.AsHelperProcessErr(err); err != nil {
 				t.Fatal(err)
 			}
@@ -377,7 +386,7 @@ func TestListSnapshots_Errors(t *testing.T) {
 
 func TestRename(t *testing.T) {
 	du := newWithFakeCmd(t, fakecmd.Options{})
-	err := du.Rename("/example/volume", "newname")
+	err := du.Rename(exampleVolumeInfo, "newname")
 	if err := fakecmd.AsHelperProcessErr(err); err != nil {
 		t.Fatal(err)
 	}
@@ -392,7 +401,7 @@ func TestRename_Errors(t *testing.T) {
 		ExitFails: map[string]bool{"diskutil": true},
 	}
 	du := newWithFakeCmd(t, fakeCmdOpts)
-	err := du.Rename("/example/volume", "newname")
+	err := du.Rename(exampleVolumeInfo, "newname")
 	if err := fakecmd.AsHelperProcessErr(err); err != nil {
 		t.Fatal(err)
 	}
@@ -404,7 +413,7 @@ func TestRename_Errors(t *testing.T) {
 
 func TestDeleteSnapshot(t *testing.T) {
 	du := newWithFakeCmd(t, fakecmd.Options{})
-	err := du.DeleteSnapshot("/example/volume", Snapshot{
+	err := du.DeleteSnapshot(exampleVolumeInfo, Snapshot{
 		Name: "example-snapshot",
 		UUID: "example-snapshot-uuid",
 	})
@@ -422,7 +431,7 @@ func TestDeleteSnapshot_Errors(t *testing.T) {
 		ExitFails: map[string]bool{"diskutil": true},
 	}
 	du := newWithFakeCmd(t, fakeCmdOpts)
-	err := du.DeleteSnapshot("/example/volume", Snapshot{
+	err := du.DeleteSnapshot(exampleVolumeInfo, Snapshot{
 		Name: "example-snapshot",
 		UUID: "example-snapshot-uuid",
 	})

--- a/diskutil/diskutil_test.go
+++ b/diskutil/diskutil_test.go
@@ -277,6 +277,28 @@ func TestListSnapshots(t *testing.T) {
 	}
 }
 
+func TestListSnapshots_IDsVolumesByUUID(t *testing.T) {
+	du := newWithFakeCmd(t, fakecmd.Options{
+			Stdouts: map[string]string{
+				"plutil": `{
+					"Snapshots": []
+				}`,
+			},
+			WantArgs: map[string]map[string]string{
+				"diskutil": map[string]string{
+					exampleVolumeInfo.UUID: "",
+				},
+			},
+	})
+	_, err := du.ListSnapshots(exampleVolumeInfo)
+	if err := fakecmd.AsHelperProcessErr(err); err != nil {
+		t.Fatal(err)
+	}
+	if err != nil {
+		t.Fatalf("ListSnapshots returned unexpected error: %q, want: nil", err)
+	}
+}
+
 func TestListSnapshots_Errors(t *testing.T) {
 	var exitErr *exec.ExitError
 	var validationErr validationError
@@ -395,6 +417,23 @@ func TestRename(t *testing.T) {
 	}
 }
 
+func TestRename_IDsVolumesByUUID(t *testing.T) {
+	du := newWithFakeCmd(t, fakecmd.Options{
+			WantArgs: map[string]map[string]string{
+				"diskutil": map[string]string{
+					exampleVolumeInfo.UUID: "",
+				},
+			},
+	})
+	err := du.Rename(exampleVolumeInfo, "newname")
+	if err := fakecmd.AsHelperProcessErr(err); err != nil {
+		t.Fatal(err)
+	}
+	if err != nil {
+		t.Fatalf("Rename returned unexpected error: %q, want: nil", err)
+	}
+}
+
 func TestRename_Errors(t *testing.T) {
 	fakeCmdOpts := fakecmd.Options{
 		Stderrs:   map[string]string{"diskutil": "example stderr"},
@@ -422,6 +461,26 @@ func TestDeleteSnapshot(t *testing.T) {
 	}
 	if err != nil {
 		t.Fatalf("DeleteSnapshot returned unexpected error: %v, want: nil", err)
+	}
+}
+
+func TestDeleteSnapshot_IDsVolumesByUUID(t *testing.T) {
+	du := newWithFakeCmd(t, fakecmd.Options{
+			WantArgs: map[string]map[string]string{
+				"diskutil": map[string]string{
+					exampleVolumeInfo.UUID: "",
+				},
+			},
+	})
+	err := du.DeleteSnapshot(exampleVolumeInfo, Snapshot{
+		Name: "example-snapshot",
+		UUID: "example-snapshot-uuid",
+	})
+	if err := fakecmd.AsHelperProcessErr(err); err != nil {
+		t.Fatal(err)
+	}
+	if err != nil {
+		t.Fatalf("Rename returned unexpected error: %q, want: nil", err)
 	}
 }
 

--- a/diskutil/diskutil_test.go
+++ b/diskutil/diskutil_test.go
@@ -18,8 +18,8 @@ func TestHelperProcess(t *testing.T) {
 	fakecmd.HelperProcess(t)
 }
 
-func newWithFakeCmd(opts fakecmd.Options) DiskUtil {
-	execCmd := fakecmd.FakeCommand(opts)
+func newWithFakeCmd(t *testing.T, opts fakecmd.Options) DiskUtil {
+	execCmd := fakecmd.FakeCommand(t, opts)
 	pl := plutil.New(plutil.WithExecCommand(execCmd))
 	return New(
 		WithExecCommand(execCmd),
@@ -89,7 +89,7 @@ func TestInfo(t *testing.T) {
 				Stderrs:    test.stderrs,
 				WantStdins: test.wantStdins,
 			}
-			du := newWithFakeCmd(fakeCmdOpts)
+			du := newWithFakeCmd(t, fakeCmdOpts)
 			got, err := du.Info("/example/volume")
 			if err := fakecmd.AsHelperProcessErr(err); err != nil {
 				t.Fatal(err)
@@ -167,7 +167,7 @@ func TestInfo_Errors(t *testing.T) {
 				WantStdins: test.wantStdins,
 				ExitFails:  test.exitFails,
 			}
-			du := newWithFakeCmd(fakeCmdOpts)
+			du := newWithFakeCmd(t, fakeCmdOpts)
 			_, err := du.Info("/example/volume")
 			if err := fakecmd.AsHelperProcessErr(err); err != nil {
 				t.Fatal(err)
@@ -250,7 +250,7 @@ func TestListSnapshots(t *testing.T) {
 				Stderrs:    test.stderrs,
 				WantStdins: test.wantStdins,
 			}
-			du := newWithFakeCmd(fakeCmdOpts)
+			du := newWithFakeCmd(t, fakeCmdOpts)
 			got, err := du.ListSnapshots("/example/volume")
 			if err := fakecmd.AsHelperProcessErr(err); err != nil {
 				t.Fatal(err)
@@ -363,7 +363,7 @@ func TestListSnapshots_Errors(t *testing.T) {
 				WantStdins: test.wantStdins,
 				ExitFails:  test.exitFails,
 			}
-			du := newWithFakeCmd(fakeCmdOpts)
+			du := newWithFakeCmd(t, fakeCmdOpts)
 			_, err := du.ListSnapshots("/example/volume")
 			if err := fakecmd.AsHelperProcessErr(err); err != nil {
 				t.Fatal(err)
@@ -376,7 +376,7 @@ func TestListSnapshots_Errors(t *testing.T) {
 }
 
 func TestRename(t *testing.T) {
-	du := newWithFakeCmd(fakecmd.Options{})
+	du := newWithFakeCmd(t, fakecmd.Options{})
 	err := du.Rename("/example/volume", "newname")
 	if err := fakecmd.AsHelperProcessErr(err); err != nil {
 		t.Fatal(err)
@@ -391,7 +391,7 @@ func TestRename_Errors(t *testing.T) {
 		Stderrs:   map[string]string{"diskutil": "example stderr"},
 		ExitFails: map[string]bool{"diskutil": true},
 	}
-	du := newWithFakeCmd(fakeCmdOpts)
+	du := newWithFakeCmd(t, fakeCmdOpts)
 	err := du.Rename("/example/volume", "newname")
 	if err := fakecmd.AsHelperProcessErr(err); err != nil {
 		t.Fatal(err)
@@ -403,7 +403,7 @@ func TestRename_Errors(t *testing.T) {
 }
 
 func TestDeleteSnapshot(t *testing.T) {
-	du := newWithFakeCmd(fakecmd.Options{})
+	du := newWithFakeCmd(t, fakecmd.Options{})
 	err := du.DeleteSnapshot("/example/volume", Snapshot{
 		Name: "example-snapshot",
 		UUID: "example-snapshot-uuid",
@@ -421,7 +421,7 @@ func TestDeleteSnapshot_Errors(t *testing.T) {
 		Stderrs:   map[string]string{"diskutil": "example stderr"},
 		ExitFails: map[string]bool{"diskutil": true},
 	}
-	du := newWithFakeCmd(fakeCmdOpts)
+	du := newWithFakeCmd(t, fakeCmdOpts)
 	err := du.DeleteSnapshot("/example/volume", Snapshot{
 		Name: "example-snapshot",
 		UUID: "example-snapshot-uuid",

--- a/diskutil/diskutil_test.go
+++ b/diskutil/diskutil_test.go
@@ -284,9 +284,9 @@ func TestListSnapshots_IDsVolumesByUUID(t *testing.T) {
 					"Snapshots": []
 				}`,
 			},
-			WantArgs: map[string]map[string]string{
-				"diskutil": map[string]string{
-					exampleVolumeInfo.UUID: "",
+			WantArgs: map[string]map[string]bool{
+				"diskutil": map[string]bool{
+					exampleVolumeInfo.UUID: true,
 				},
 			},
 	})
@@ -419,9 +419,9 @@ func TestRename(t *testing.T) {
 
 func TestRename_IDsVolumesByUUID(t *testing.T) {
 	du := newWithFakeCmd(t, fakecmd.Options{
-			WantArgs: map[string]map[string]string{
-				"diskutil": map[string]string{
-					exampleVolumeInfo.UUID: "",
+			WantArgs: map[string]map[string]bool{
+				"diskutil": map[string]bool{
+					exampleVolumeInfo.UUID: true,
 				},
 			},
 	})
@@ -466,9 +466,9 @@ func TestDeleteSnapshot(t *testing.T) {
 
 func TestDeleteSnapshot_IDsVolumesByUUID(t *testing.T) {
 	du := newWithFakeCmd(t, fakecmd.Options{
-			WantArgs: map[string]map[string]string{
-				"diskutil": map[string]string{
-					exampleVolumeInfo.UUID: "",
+			WantArgs: map[string]map[string]bool{
+				"diskutil": map[string]bool{
+					exampleVolumeInfo.UUID: true,
 				},
 			},
 	})

--- a/plutil/plutil_test.go
+++ b/plutil/plutil_test.go
@@ -66,7 +66,7 @@ func TestDecodePlist(t *testing.T) {
 				Stderrs:    map[string]string{"plutil": test.stderr},
 				WantStdins: map[string]string{"plutil": test.wantStdin},
 			}
-			execCmd := fakecmd.FakeCommand(fakeCmdOpts)
+			execCmd := fakecmd.FakeCommand(t, fakeCmdOpts)
 			pl := New(WithExecCommand(execCmd))
 			got := simpleStruct{}
 			err := pl.DecodePlist(test.r, &got)
@@ -115,7 +115,7 @@ func TestDecodePlist_Errors(t *testing.T) {
 				Stderrs:   map[string]string{"plutil": test.stderr},
 				ExitFails: map[string]bool{"plutil": test.exitFail},
 			}
-			execCmd := fakecmd.FakeCommand(fakeCmdOpts)
+			execCmd := fakecmd.FakeCommand(t, fakeCmdOpts)
 			pl := New(WithExecCommand(execCmd))
 			err := pl.DecodePlist(nil, &simpleStruct{})
 			if err := fakecmd.AsHelperProcessErr(err); err != nil {

--- a/testutils/fakecmd/fakecmd.go
+++ b/testutils/fakecmd/fakecmd.go
@@ -63,18 +63,18 @@ import (
 )
 
 // Options defines the behaviors of commands faked by FakeCommand. All keys in
-// the maps are command names.
+// the top-level maps are command names.
 type Options struct {
 	// Value to output to stdout.
 	Stdouts map[string]string
 	// Value to output to stderr.
 	Stderrs map[string]string
+	// If true, the command will exit with exit code 1.
+	ExitFails map[string]bool
 	// Value expected by stdin. If another value is received, the helper
 	// process exits in such a way that AsHelperProcessErr returns non-nil.
 	WantStdins map[string]string
-	// If true, the command will exit with exit code 1.
-	ExitFails map[string]bool
-	// TODO: document.
+	// Set of args the command is expected to be called with.
 	WantArgs map[string]map[string]bool
 }
 


### PR DESCRIPTION
This PR adds the `WantArgs` field in `fakecmd.Options`, which is a set of args the command is expected to be called with. Note that this only tests for the presence of each argument, and does not test key-value pairs.

Also change `asr.Restore` to identify volumes by device node rather than mount point.