### PR TITLE
--dryrun flag

### DIFF
--- a/asr/asr.go
+++ b/asr/asr.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"os/exec"
 
@@ -41,7 +40,7 @@ func (a ASR) Restore(source, target diskutil.VolumeInfo, to, from diskutil.Snaps
 	cmd.Stdout = a.osStdout
 	stderr := new(bytes.Buffer)
 	cmd.Stderr = stderr
-	log.Printf("Running command:\n%s", cmd)
+	fmt.Fprintf(a.osStdout, "Running command:\n%s\n", cmd)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("`%s` failed (%w) with stderr: %s", cmd, err, stderr.String())
 	}
@@ -61,7 +60,7 @@ func (a ASR) DestructiveRestore(source, target diskutil.VolumeInfo, to diskutil.
 	cmd.Stdout = a.osStdout
 	stderr := new(bytes.Buffer)
 	cmd.Stderr = stderr
-	log.Printf("Running command:\n%s", cmd)
+	fmt.Fprintf(a.osStdout, "Running command:\n%s\n", cmd)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("`%s` failed (%w) with stderr: %s", cmd, err, stderr.String())
 	}

--- a/asr/asr.go
+++ b/asr/asr.go
@@ -13,23 +13,55 @@ import (
 )
 
 // ASR restores a target volume to a source volume's APFS snapshot.
-type ASR struct {
+type ASR interface {
+	Restore(source, target diskutil.VolumeInfo, to, from diskutil.Snapshot) error
+	DestructiveRestore(source, target diskutil.VolumeInfo, to diskutil.Snapshot) error
+}
+
+type asr struct {
+	config
+}
+
+// config contains fields shared between asr and dryRunASR.
+type config struct {
 	execCommand func(string, ...string) *exec.Cmd
-	osStdout    io.Writer
+	stdout      io.Writer
+}
+
+// Option configures the behavior of ASR.
+type Option func(*config)
+
+// Stdout returns an Option that sets the stdout to the given io.Writer.
+func Stdout(w io.Writer) Option {
+	return func(conf *config) {
+		conf.stdout = w
+	}
+}
+
+func withExecCmd(f func(string, ...string) *exec.Cmd) Option {
+	return func(conf *config) {
+		conf.execCommand = f
+	}
 }
 
 // New returns a new ASR.
-func New() ASR {
-	return ASR{
+func New(opts ...Option) ASR {
+	conf := config{
 		execCommand: exec.Command,
-		osStdout:    os.Stdout,
+		stdout:      os.Stdout,
+	}
+	for _, opt := range opts {
+		opt(&conf)
+	}
+	return asr{
+		config: conf,
 	}
 }
 
 // Restore the target volume to the source volume's `to` snapshot, from the
 // target volume's `from` snapshot. Both to and from must exist in source. From
 // must also exist in target.
-func (a ASR) Restore(source, target diskutil.VolumeInfo, to, from diskutil.Snapshot) error {
+func (a asr) Restore(source, target diskutil.VolumeInfo, to, from diskutil.Snapshot) error {
 	cmd := a.execCommand(
 		"asr", "restore",
 		"--source", source.Device,
@@ -37,10 +69,9 @@ func (a ASR) Restore(source, target diskutil.VolumeInfo, to, from diskutil.Snaps
 		"--toSnapshot", to.UUID,
 		"--fromSnapshot", from.UUID,
 		"--erase", "--noprompt")
-	cmd.Stdout = a.osStdout
+	cmd.Stdout = a.stdout
 	stderr := new(bytes.Buffer)
 	cmd.Stderr = stderr
-	fmt.Fprintf(a.osStdout, "Running command:\n%s\n", cmd)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("`%s` failed (%w) with stderr: %s", cmd, err, stderr.String())
 	}
@@ -50,17 +81,16 @@ func (a ASR) Restore(source, target diskutil.VolumeInfo, to, from diskutil.Snaps
 // DestructiveRestore restores the target volume to the source volume's `to`
 // snapshot. `to` must exist in source. target's previous data and snapshots
 // will be lost. Use with caution!
-func (a ASR) DestructiveRestore(source, target diskutil.VolumeInfo, to diskutil.Snapshot) error {
+func (a asr) DestructiveRestore(source, target diskutil.VolumeInfo, to diskutil.Snapshot) error {
 	cmd := a.execCommand(
 		"asr", "restore",
 		"--source", source.Device,
 		"--target", target.Device,
 		"--toSnapshot", to.UUID,
 		"--erase", "--noprompt")
-	cmd.Stdout = a.osStdout
+	cmd.Stdout = a.stdout
 	stderr := new(bytes.Buffer)
 	cmd.Stderr = stderr
-	fmt.Fprintf(a.osStdout, "Running command:\n%s\n", cmd)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("`%s` failed (%w) with stderr: %s", cmd, err, stderr.String())
 	}

--- a/asr/asr_test.go
+++ b/asr/asr_test.go
@@ -21,9 +21,12 @@ func TestRestore_WritesOutputToStdout(t *testing.T) {
 	defer pr.Close()
 	defer pw.Close()
 
-	a := New()
-	a.execCommand = fakecmd.FakeCommand(t, fakecmd.Stdout("asr", "want stdout"))
-	a.osStdout = pw
+	a := New(
+		Stdout(pw),
+		withExecCmd(fakecmd.FakeCommand(t,
+			fakecmd.Stdout("asr", "want stdout"),
+		)),
+	)
 
 	dummyVolume := diskutil.VolumeInfo{}
 	dummySnap := diskutil.Snapshot{}
@@ -70,14 +73,13 @@ func TestRestore_CmdArgs(t *testing.T) {
 		Name: "from-snapshot-name",
 	}
 
-	a := New()
 	opts := []fakecmd.Option{
 		fakecmd.WantArg("asr", source.Device),
 		fakecmd.WantArg("asr", target.Device),
 		fakecmd.WantArg("asr", to.UUID),
 		fakecmd.WantArg("asr", from.UUID),
 	}
-	a.execCommand = fakecmd.FakeCommand(t, opts...)
+	a := New(withExecCmd(fakecmd.FakeCommand(t, opts...)))
 	err := a.Restore(source, target, to, from)
 	if err := fakecmd.AsHelperProcessErr(err); err != nil {
 		t.Fatal(err)

--- a/asr/dryrun.go
+++ b/asr/dryrun.go
@@ -1,19 +1,34 @@
 package asr
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/voidingwarranties/offsite-apfs-backup/diskutil"
 )
 
-type DryRunASR struct {}
-
-func NewDryRun() DryRunASR {
-	return DryRunASR{}
+type dryRun struct {
+	config
 }
 
-func (dry DryRunASR) Restore(source, target diskutil.VolumeInfo, to, from diskutil.Snapshot) error {
+func NewDryRun(opts ...Option) ASR {
+	conf := config{
+		stdout: os.Stdout,
+	}
+	for _, opt := range opts {
+		opt(&conf)
+	}
+	return dryRun{
+		config: conf,
+	}
+}
+
+func (dry dryRun) Restore(source, target diskutil.VolumeInfo, to, from diskutil.Snapshot) error {
+	fmt.Fprintln(dry.stdout, "Restore completed successfully.")
 	return nil
 }
 
-func (dry DryRunASR) DestructiveRestore(source, target diskutil.VolumeInfo, to diskutil.Snapshot) error {
+func (dry dryRun) DestructiveRestore(source, target diskutil.VolumeInfo, to diskutil.Snapshot) error {
+	fmt.Fprintln(dry.stdout, "Restore completed successfully.")
 	return nil
 }

--- a/asr/dryrun.go
+++ b/asr/dryrun.go
@@ -1,0 +1,19 @@
+package asr
+
+import (
+	"github.com/voidingwarranties/offsite-apfs-backup/diskutil"
+)
+
+type DryRunASR struct {}
+
+func NewDryRun() DryRunASR {
+	return DryRunASR{}
+}
+
+func (dry DryRunASR) Restore(source, target diskutil.VolumeInfo, to, from diskutil.Snapshot) error {
+	return nil
+}
+
+func (dry DryRunASR) DestructiveRestore(source, target diskutil.VolumeInfo, to diskutil.Snapshot) error {
+	return nil
+}

--- a/cloner/cloner.go
+++ b/cloner/cloner.go
@@ -32,6 +32,14 @@ func InitializeTargets(initTargets bool) Option {
 	}
 }
 
+// TODO: document.
+func DryRun(dryrun bool) Option {
+	return func(c *Cloner) {
+		withDiskUtil(diskutil.NewDryRun())(c)
+		withASR(asr.NewDryRun())(c)
+	}
+}
+
 func withDiskUtil(du du) Option {
 	return func(c *Cloner) {
 		c.diskutil = du

--- a/cloner/cloner.go
+++ b/cloner/cloner.go
@@ -4,7 +4,6 @@ package cloner
 import (
 	"errors"
 	"fmt"
-	"log"
 
 	"github.com/voidingwarranties/offsite-apfs-backup/asr"
 	"github.com/voidingwarranties/offsite-apfs-backup/diskutil"
@@ -167,7 +166,7 @@ func (c Cloner) cloneable(sourceSnaps, targetSnaps []diskutil.Snapshot) error {
 // Clone the latest snapshot in source to target, from the most recent common
 // snapshot present in both source and target.
 func (c Cloner) Clone(source, target string) error {
-	log.Printf("Cloning %q to %q...", source, target)
+	fmt.Printf("Cloning %q to %q...\n", source, target)
 
 	sourceInfo, err := c.diskutil.Info(source)
 	if err != nil {
@@ -208,17 +207,17 @@ func (c Cloner) clone(source, target diskutil.VolumeInfo) error {
 	if err != nil {
 		return fmt.Errorf("error finding latest snapshot in common between source and target: %v", err)
 	}
-	log.Printf("Found snapshot in common: %s", commonSnap)
+	fmt.Printf("Found snapshot in common: %s\n", commonSnap)
 
 	// TODO: document that this relies on the snapshots being in the right order.
 	latestSourceSnap := sourceSnaps[0]
-	log.Printf("Restoring to latest snapshot in source, %s, from common snapshot", latestSourceSnap)
+	fmt.Printf("Restoring to latest snapshot in source, %s, from common snapshot\n", latestSourceSnap)
 	if err := c.asr.Restore(source, target, latestSourceSnap, commonSnap); err != nil {
 		return fmt.Errorf("error restoring: %v", err)
 	}
 
 	if c.prune {
-		log.Print("Pruning common snapshot from target...")
+		fmt.Println("Pruning common snapshot from target...")
 		if err := c.diskutil.DeleteSnapshot(target, commonSnap); err != nil {
 			return fmt.Errorf("error deleting snapshot %q from target", commonSnap)
 		}
@@ -243,7 +242,7 @@ func (c Cloner) destructiveClone(source, target diskutil.VolumeInfo) error {
 	}
 	// TODO: document that this relies on the snapshots being in the right order.
 	latestSourceSnap := sourceSnaps[0]
-	log.Printf("Restoring to latest snapshot in source, %s", latestSourceSnap)
+	fmt.Printf("Restoring to latest snapshot in source, %s\n", latestSourceSnap)
 	if err := c.asr.DestructiveRestore(source, target, latestSourceSnap); err != nil {
 		return fmt.Errorf("error restoring: %v", err)
 	}

--- a/cloner/cloner.go
+++ b/cloner/cloner.go
@@ -4,6 +4,8 @@ package cloner
 import (
 	"errors"
 	"fmt"
+	"io"
+	"os"
 
 	"github.com/voidingwarranties/offsite-apfs-backup/asr"
 	"github.com/voidingwarranties/offsite-apfs-backup/diskutil"
@@ -31,31 +33,20 @@ func InitializeTargets(initTargets bool) Option {
 	}
 }
 
-// TODO: document.
-func DryRun(dryrun bool) Option {
+// Stdout returns an Option that sets the stdout to the given io.Writer.
+func Stdout(w io.Writer) Option {
 	return func(c *Cloner) {
-		withDiskUtil(diskutil.NewDryRun())(c)
-		withASR(asr.NewDryRun())(c)
-	}
-}
-
-func withDiskUtil(du du) Option {
-	return func(c *Cloner) {
-		c.diskutil = du
-	}
-}
-
-func withASR(r restorer) Option {
-	return func(c *Cloner) {
-		c.asr = r
+		c.stdout = w
 	}
 }
 
 // New returns a new Cloner with the given options.
-func New(opts ...Option) Cloner {
+func New(du diskutil.DiskUtil, r asr.ASR, opts ...Option) Cloner {
 	c := Cloner{
-		diskutil: diskutil.New(),
-		asr:      asr.New(),
+		diskutil: du,
+		asr:      r,
+
+		stdout: os.Stdout,
 
 		prune:       false,
 		initTargets: false,
@@ -68,23 +59,13 @@ func New(opts ...Option) Cloner {
 
 // Cloner clones APFS volumes using APFS snapshot diffs.
 type Cloner struct {
-	diskutil du
-	asr      restorer
+	diskutil diskutil.DiskUtil
+	asr      asr.ASR
+
+	stdout io.Writer
 
 	prune       bool
 	initTargets bool
-}
-
-type du interface {
-	Info(volume string) (diskutil.VolumeInfo, error)
-	Rename(volume diskutil.VolumeInfo, name string) error
-	ListSnapshots(volume diskutil.VolumeInfo) ([]diskutil.Snapshot, error)
-	DeleteSnapshot(volume diskutil.VolumeInfo, snap diskutil.Snapshot) error
-}
-
-type restorer interface {
-	Restore(source, target diskutil.VolumeInfo, to, from diskutil.Snapshot) error
-	DestructiveRestore(source, target diskutil.VolumeInfo, to diskutil.Snapshot) error
 }
 
 // Cloneable returns nil if source is cloneable to all targets, where cloneable
@@ -166,8 +147,6 @@ func (c Cloner) cloneable(sourceSnaps, targetSnaps []diskutil.Snapshot) error {
 // Clone the latest snapshot in source to target, from the most recent common
 // snapshot present in both source and target.
 func (c Cloner) Clone(source, target string) error {
-	fmt.Printf("Cloning %q to %q...\n", source, target)
-
 	sourceInfo, err := c.diskutil.Info(source)
 	if err != nil {
 		return fmt.Errorf("error getting volume info of source %q: %v", source, err)
@@ -199,6 +178,13 @@ func (c Cloner) clone(source, target diskutil.VolumeInfo) error {
 	if err != nil {
 		return fmt.Errorf("error listing snapshots of source: %v", err)
 	}
+	if len(sourceSnaps) == 0 {
+		return errors.New("source does not contain any snapshots")
+	}
+	// TODO: document that this relies on the snapshots being in the right order.
+	latestSourceSnap := sourceSnaps[0]
+	fmt.Fprintf(c.stdout, "Latest snapshot in source:\n\t%s\n", latestSourceSnap)
+
 	targetSnaps, err := c.diskutil.ListSnapshots(target)
 	if err != nil {
 		return fmt.Errorf("error listing snapshots of target: %v", err)
@@ -207,20 +193,18 @@ func (c Cloner) clone(source, target diskutil.VolumeInfo) error {
 	if err != nil {
 		return fmt.Errorf("error finding latest snapshot in common between source and target: %v", err)
 	}
-	fmt.Printf("Found snapshot in common: %s\n", commonSnap)
+	fmt.Fprintf(c.stdout, "Snapshot in common:\n\t%s\n", commonSnap)
 
-	// TODO: document that this relies on the snapshots being in the right order.
-	latestSourceSnap := sourceSnaps[0]
-	fmt.Printf("Restoring to latest snapshot in source, %s, from common snapshot\n", latestSourceSnap)
+	fmt.Fprintln(c.stdout, "Restoring to latest snapshot in source from common snapshot...")
 	if err := c.asr.Restore(source, target, latestSourceSnap, commonSnap); err != nil {
 		return fmt.Errorf("error restoring: %v", err)
 	}
 
 	if c.prune {
-		fmt.Println("Pruning common snapshot from target...")
 		if err := c.diskutil.DeleteSnapshot(target, commonSnap); err != nil {
 			return fmt.Errorf("error deleting snapshot %q from target", commonSnap)
 		}
+		fmt.Fprintln(c.stdout, "Pruned common snapshot from target.")
 	}
 	return nil
 }
@@ -233,6 +217,10 @@ func (c Cloner) destructiveClone(source, target diskutil.VolumeInfo) error {
 	if len(sourceSnaps) == 0 {
 		return errors.New("source does not contain any snapshots")
 	}
+	// TODO: document that this relies on the snapshots being in the right order.
+	latestSourceSnap := sourceSnaps[0]
+	fmt.Fprintf(c.stdout, "Latest snapshot in source:\n\t%s\n", latestSourceSnap)
+
 	targetSnaps, err := c.diskutil.ListSnapshots(target)
 	if err != nil {
 		return fmt.Errorf("error listing snapshots of target: %v", err)
@@ -240,9 +228,7 @@ func (c Cloner) destructiveClone(source, target diskutil.VolumeInfo) error {
 	if len(targetSnaps) > 0 {
 		return errors.New("aborting because target contains snapshots that would be erased")
 	}
-	// TODO: document that this relies on the snapshots being in the right order.
-	latestSourceSnap := sourceSnaps[0]
-	fmt.Printf("Restoring to latest snapshot in source, %s\n", latestSourceSnap)
+	fmt.Fprintln(c.stdout, "Restoring to latest snapshot in source...")
 	if err := c.asr.DestructiveRestore(source, target, latestSourceSnap); err != nil {
 		return fmt.Errorf("error restoring: %v", err)
 	}

--- a/cloner/cloner_fakes_test.go
+++ b/cloner/cloner_fakes_test.go
@@ -147,17 +147,10 @@ func (du *fakeDiskUtil) DeleteSnapshot(volume diskutil.VolumeInfo, snap diskutil
 	return du.devices.DeleteSnapshot(volume.UUID, snap.UUID)
 }
 
-type DiskUtil interface {
-	Info(volume string) (diskutil.VolumeInfo, error)
-	Rename(volume diskutil.VolumeInfo, name string) error
-	ListSnapshots(volume diskutil.VolumeInfo) ([]diskutil.Snapshot, error)
-	DeleteSnapshot(volume diskutil.VolumeInfo, snap diskutil.Snapshot) error
-}
-
 type readonlyFakeDiskUtil struct {
 	du *fakeDiskUtil
 
-	DiskUtil
+	diskutil.DiskUtil
 }
 
 func (du *readonlyFakeDiskUtil) Info(volume string) (diskutil.VolumeInfo, error) {

--- a/diskutil/diskutil.go
+++ b/diskutil/diskutil.go
@@ -5,7 +5,6 @@ package diskutil
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"regexp"
@@ -78,8 +77,6 @@ func (du DiskUtil) Rename(volume VolumeInfo, name string) error {
 	cmd.Stdout = os.Stdout
 	stderr := new(bytes.Buffer)
 	cmd.Stderr = stderr
-
-	log.Printf("Running command:\n%s", cmd)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("`%s` failed (%w) with stderr: %s", cmd, err, stderr)
 	}
@@ -163,8 +160,6 @@ func (du DiskUtil) DeleteSnapshot(volume VolumeInfo, snap Snapshot) error {
 	cmd.Stdout = os.Stdout
 	stderr := new(bytes.Buffer)
 	cmd.Stderr = stderr
-
-	log.Printf("Running command:\n%s", cmd)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("`%s` failed (%w) with stderr: %s", cmd, err, stderr)
 	}
@@ -172,7 +167,6 @@ func (du DiskUtil) DeleteSnapshot(volume VolumeInfo, snap Snapshot) error {
 }
 
 func (du DiskUtil) runAndDecodePlist(cmd *exec.Cmd, v interface{}) error {
-	log.Printf("Running command:\n%s", cmd)
 	stdout, err := cmd.Output()
 	if err != nil {
 		var errMsg plistErrorMessage

--- a/diskutil/dryrun.go
+++ b/diskutil/dryrun.go
@@ -1,27 +1,30 @@
 package diskutil
 
-type DryRunDiskUtil struct {
+type dryRun struct {
 	du DiskUtil
 }
 
-func NewDryRun(opts ...option) DryRunDiskUtil {
-	return DryRunDiskUtil{
-		du: New(opts...),
+// NewDryRun returns a DiskUtil that cannot modify any volumes. All
+// readonly methods (Info and ListSnapshots) are passed through to the
+// underlying DiskUtil, du.
+func NewDryRun(du DiskUtil) DiskUtil {
+	return dryRun{
+		du: du,
 	}
 }
 
-func (dry DryRunDiskUtil) Info(volume string) (VolumeInfo, error) {
+func (dry dryRun) Info(volume string) (VolumeInfo, error) {
 	return dry.du.Info(volume)
 }
 
-func (dry DryRunDiskUtil) Rename(volume VolumeInfo, name string) error {
+func (dry dryRun) Rename(volume VolumeInfo, name string) error {
 	return nil
 }
 
-func (dry DryRunDiskUtil) ListSnapshots(volume VolumeInfo) ([]Snapshot, error) {
+func (dry dryRun) ListSnapshots(volume VolumeInfo) ([]Snapshot, error) {
 	return dry.du.ListSnapshots(volume)
 }
 
-func (dry DryRunDiskUtil) DeleteSnapshot(volume VolumeInfo, snap Snapshot) error {
+func (dry dryRun) DeleteSnapshot(volume VolumeInfo, snap Snapshot) error {
 	return nil
 }

--- a/diskutil/dryrun.go
+++ b/diskutil/dryrun.go
@@ -1,0 +1,27 @@
+package diskutil
+
+type DryRunDiskUtil struct {
+	du DiskUtil
+}
+
+func NewDryRun(opts ...option) DryRunDiskUtil {
+	return DryRunDiskUtil{
+		du: New(opts...),
+	}
+}
+
+func (dry DryRunDiskUtil) Info(volume string) (VolumeInfo, error) {
+	return dry.du.Info(volume)
+}
+
+func (dry DryRunDiskUtil) Rename(volume VolumeInfo, name string) error {
+	return nil
+}
+
+func (dry DryRunDiskUtil) ListSnapshots(volume VolumeInfo) ([]Snapshot, error) {
+	return dry.du.ListSnapshots(volume)
+}
+
+func (dry DryRunDiskUtil) DeleteSnapshot(volume VolumeInfo, snap Snapshot) error {
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 
@@ -82,11 +81,12 @@ func main() {
 	for _, target := range targets {
 		if err := c.Clone(source, target); err != nil {
 			errs[target] = err
-			log.Printf("failed to clone %q to %q: %v", source, target, err)
+			fmt.Fprintf(os.Stderr, "failed to clone %q to %q: %v\n", source, target, err)
 		}
 	}
 	if len(errs) > 0 {
-		log.Fatalf("failed to clone to %d/%d targets", len(errs), len(targets))
+		fmt.Fprintf(os.Stderr, "failed to clone to %d/%d targets\n", len(errs), len(targets))
+		os.Exit(1)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -20,11 +20,13 @@ Incompatible with -initialize.`)
 Set -initialize to true when first setting up an off-site backup volume.
 If false (default), nondestructively clone the latest APFS snapshot in source to targets using the latest snapshot in common.
 Incompatible with -prune.`)
+	dryrun = flag.Bool("dryrun", false, `If true, only print the changes that would have been made to targets.
+Does not modify targets in any way.`)
 )
 
 func init() {
 	flag.Usage = func() {
-		fmt.Fprintf(flag.CommandLine.Output(), `Usage: %s [-prune] [-initialize] [--] <source volume> <target volume> [<target volume>...]
+		fmt.Fprintf(flag.CommandLine.Output(), `Usage: %s [-prune] [-initialize] [-dryrun] [--] <source volume> <target volume> [<target volume>...]
 
   <source volume>
     	Source APFS volume to clone.
@@ -57,7 +59,11 @@ func main() {
 		flag.Usage()
 		os.Exit(1)
 	}
-	c := cloner.New(cloner.Prune(*prune), cloner.InitializeTargets(*initialize))
+	c := cloner.New(
+		cloner.Prune(*prune),
+		cloner.InitializeTargets(*initialize),
+		cloner.DryRun(*dryrun),
+	)
 	if err := c.Cloneable(source, targets...); err != nil {
 		fmt.Fprintln(os.Stderr, "Error:", err)
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -87,9 +87,11 @@ func main() {
 		fmt.Fprintln(os.Stderr, "Error:", err)
 		os.Exit(1)
 	}
-	if err := confirm(source, targets); err != nil {
-		fmt.Fprintln(flag.CommandLine.Output(), "Error:", err)
-		os.Exit(1)
+	if !*dryrun {
+		if err := confirm(source, targets); err != nil {
+			fmt.Fprintln(flag.CommandLine.Output(), "Error:", err)
+			os.Exit(1)
+		}
 	}
 
 	errs := make(map[string]error) // Map of target volume to clone error.


### PR DESCRIPTION
When dry run is true, the changes that would have been made are printed instead of making the changes. This is implemented by providing a fake DiskUtil and ASR that pass through all readonly methods through to a real DiskUtil / ASR, but whose modifying methods are no-ops.

Also cleaned up the informational print messages. Now prints to stdout rather than using the log package. Messages printed by cloner, diskutil, and ASR are indented to distinguish between clones to different targets. e.g.
Before:
```
Cloning "/Volumes/source" to "/Volumes/target1"...
Latest snapshot in source: com.bombich.ccc.6AE4815C-1F9A-4D5E-86E1-19078BE01958.2021-03-01-203509 (D1ABE254-5B1B-4FDF-8DB3-1B4B4B825E39)
Snapshot in common: com.bombich.ccc.D7B2D286-3CE0-40B9-9797-EBF108ADAD30.2021-03-01-203433 (A175CCCF-0C56-4A46-97FB-CA267A540C96)
Restoring to latest snapshot in source from common snapshot...
	Validating target...done
	Validating source...done
	Replicating ....10....20....30....40....50....60....70....80....90....100
	Restored target device is /dev/disk7s1.
	Remounting target volume...done
Restore completed successfully.
Cloning "/Volumes/source" to "/Volumes/target2"...
Latest snapshot in source: com.bombich.ccc.6AE4815C-1F9A-4D5E-86E1-19078BE01958.2021-03-01-203509 (D1ABE254-5B1B-4FDF-8DB3-1B4B4B825E39)
Snapshot in common: com.bombich.ccc.D7B2D286-3CE0-40B9-9797-EBF108ADAD30.2021-03-01-203433 (A175CCCF-0C56-4A46-97FB-CA267A540C96)
Restoring to latest snapshot in source from common snapshot...
	Validating target...done
	Validating source...done
	Replicating ....10....20....30....40....50....60....70....80....90....100
	Restored target device is /dev/disk8s1.
	Remounting target volume...done
Restore completed successfully.
```
After:
```
Cloning "/Volumes/source" to "/Volumes/target1"...
	Latest snapshot in source:
		com.bombich.ccc.6AE4815C-1F9A-4D5E-86E1-19078BE01958.2021-03-01-203509 (D1ABE254-5B1B-4FDF-8DB3-1B4B4B825E39)
	Snapshot in common:
		com.bombich.ccc.D7B2D286-3CE0-40B9-9797-EBF108ADAD30.2021-03-01-203433 (A175CCCF-0C56-4A46-97FB-CA267A540C96)
	Restoring to latest snapshot in source from common snapshot...
		Validating target...done
		Validating source...done
		Replicating ....10....20....30....40....50....60....70....80....90....100
		Restored target device is /dev/disk7s1.
		Remounting target volume...done
	Restore completed successfully.
Cloning "/Volumes/source" to "/Volumes/target2"...
	Latest snapshot in source:
		com.bombich.ccc.6AE4815C-1F9A-4D5E-86E1-19078BE01958.2021-03-01-203509 (D1ABE254-5B1B-4FDF-8DB3-1B4B4B825E39)
	Snapshot in common:
		com.bombich.ccc.D7B2D286-3CE0-40B9-9797-EBF108ADAD30.2021-03-01-203433 (A175CCCF-0C56-4A46-97FB-CA267A540C96)
	Restoring to latest snapshot in source from common snapshot...
		Validating target...done
		Validating source...done
		Replicating ....10....20....30....40....50....60....70....80....90....100
		Restored target device is /dev/disk8s1.
		Remounting target volume...done
	Restore completed successfully.
```